### PR TITLE
feat: 🎸 setup chat with websocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "multer-storage-cloudinary": "^4.0.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
+    "socket.io": "^4.7.5",
     "swagger-autogen": "^2.23.7",
     "swagger-ui-express": "^5.0.0",
     "typescript-json-schema": "^0.63.0",

--- a/postman-collection.json
+++ b/postman-collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "_postman_id": "51722f4b-fbf9-4062-952b-576766be5315",
+    "_postman_id": "f6b33cea-df08-468d-9fa4-96fe74a04842",
     "name": "chillka-backend",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "20616853"
@@ -327,6 +327,37 @@
               "value": ""
             }
           ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "get message list id",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "",
+            "value": "",
+            "disabled": true
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"orderId\": \"\",\n    \"hostUserId\": \"\",\n    \"participantUserId\": \"\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{HOST}}/api/auth/messageListId",
+          "host": ["{{HOST}}"],
+          "path": ["api", "auth", "messageListId"]
         }
       },
       "response": []

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,12 +1,16 @@
 import 'dotenv/config';
 import express from 'express';
+import http from 'http';
 import mongoose from 'mongoose';
+import { Server } from 'socket.io';
 import swaggerUi from 'swagger-ui-express';
 import User from './model/user.model';
 import authRoute from './route/auth.route';
+import messageRoute from './route/message-list.route';
 import orderRoute from './route/order.route';
 import paymentRoute from './route/payment.route';
 import publicActivityRoute from './route/publicActivity.route';
+import socketRoute from './route/socket.route';
 import swaggerRoute from './route/swagger.route';
 import userRoute from './route/user.route';
 import userActivityRoute from './route/userActivity.route';
@@ -15,6 +19,8 @@ import googleStrategy from './util/google-strategy';
 
 const app = express();
 const port = process.env.PORT;
+const server = http.createServer(app);
+const io = new Server(server);
 const options = {
   customCss: '.swagger-ui .topbar { display: none }',
   swaggerOptions: {
@@ -41,7 +47,8 @@ app.use(
   userRoute,
   userActivityRoute,
   orderRoute,
-  paymentRoute
+  paymentRoute,
+  messageRoute
 );
 app.use(
   '/api-docs',
@@ -60,6 +67,8 @@ mongoose.connect(process.env.MONGODB_URL ?? '').then(() => {
   console.log('Connected to the database by mongoose');
 });
 
-app.listen(port, () => {
+socketRoute(io);
+
+server.listen(port, () => {
   console.log(`Example app listening at http://localhost:${port}`);
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,6 +58,8 @@ app.use(
 
 // delete me in production
 app.get('/api/demo', async (req, res) => {
+  /* #swagger.description = 'Validate all of users' email' */
+
   await User.updateMany({ isEmailValidate: false }, { isEmailValidate: true });
 
   res.send('success validate email');

--- a/src/middleware/validate.middleware.ts
+++ b/src/middleware/validate.middleware.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import { ZodError, ZodTypeAny } from 'zod';
 import { CoreError, throwAPIError } from '../util/error-handler';
+import { zodErrorHandler } from '../util/zod/zodError-hanlder';
 
 export const zodValidateMiddleware =
   <T extends ZodTypeAny>(schema: T) =>
@@ -13,12 +14,8 @@ export const zodValidateMiddleware =
       return next();
     } catch (error) {
       if (error instanceof ZodError) {
-        const problem = error.flatten();
-        const fieldErrors = problem.fieldErrors;
-        const fieldErrorsString = Object.entries(fieldErrors)
-          .map(([key, value]) => `${key}: ${value?.join(', ')}`)
-          .join('\n');
-        const coreError = new CoreError(fieldErrorsString);
+        const zodError = zodErrorHandler(error);
+        const coreError = new CoreError(zodError);
 
         throwAPIError({ res, error: coreError, statusCode: 400 });
       } else {

--- a/src/model/message-list.model.ts
+++ b/src/model/message-list.model.ts
@@ -1,0 +1,61 @@
+import { Model, Schema, model } from 'mongoose';
+import {
+  MessageListSchemaModel,
+  MessageSchemaModel,
+  MessageUserType,
+} from '../type/message-list.type';
+
+type Message = Model<MessageSchemaModel, object>;
+type MessageListModel = Model<MessageListSchemaModel, object>;
+
+const Message = new Schema<MessageSchemaModel, Message>(
+  {
+    userType: {
+      type: Schema.Types.String,
+      enum: MessageUserType,
+      required: true,
+    },
+    content: {
+      type: Schema.Types.String,
+      required: true,
+    },
+  },
+  {
+    collection: 'messages',
+    timestamps: true,
+  }
+);
+
+const MessageListSchema = new Schema<MessageListSchemaModel, MessageListModel>(
+  {
+    orderId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Order',
+      required: true,
+    },
+    hostUserId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    participantUserId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    messages: {
+      type: [Message],
+    },
+  },
+  {
+    collection: 'message-lists',
+    timestamps: true,
+  }
+);
+
+const MessageList = model<MessageListSchemaModel, MessageListModel>(
+  'MessageList',
+  MessageListSchema
+);
+
+export default MessageList;

--- a/src/model/order.model.ts
+++ b/src/model/order.model.ts
@@ -41,7 +41,7 @@ const OrderSchema = new Schema<OrderSchemaModel, OrderModel>(
     },
     payment: {
       amount: {
-        type: Schema.Types.Number,
+        type: Schema.Types.String,
         required: true,
       },
       status: {

--- a/src/route/auth.route.ts
+++ b/src/route/auth.route.ts
@@ -47,6 +47,8 @@ const authRouter = () => {
 
   router.get(
     '/google-oauth',
+    /* #swagger.ignore = true */
+
     passport.authenticate('google', {
       scope: ['email', 'profile'],
     })
@@ -54,6 +56,8 @@ const authRouter = () => {
 
   router.get(
     '/google-oauth/callback',
+    /* #swagger.ignore = true */
+
     passport.authenticate('google', {
       session: false,
       failureRedirect: process.env.FRONTEND?.concat(

--- a/src/route/message-list.route.ts
+++ b/src/route/message-list.route.ts
@@ -13,6 +13,10 @@ const messageRouter = () => {
     authorizeMiddleware,
     zodValidateMiddleware(messageListIdSchema),
     async (req: Request, res: Response) => {
+      /* #swagger.tags = ['MessageList'] 
+          #swagger.parameters['body'] = { in: 'body', schema: { $ref: "#/schemas/GetMessageListParams" }}
+      */
+
       const { orderId, hostUserId, participantUserId } = req.body;
       try {
         const data = await MessageListService.getMessageListId({

--- a/src/route/message-list.route.ts
+++ b/src/route/message-list.route.ts
@@ -1,0 +1,35 @@
+import { Request, Response, Router } from 'express';
+import mongoose from 'mongoose';
+import authorizeMiddleware from '../middleware/authorize.middleware';
+import { zodValidateMiddleware } from '../middleware/validate.middleware';
+import * as MessageListService from '../service/message-list.service';
+import { throwAPIError } from '../util/error-handler';
+import { messageListIdSchema } from '../util/zod/message-list.schema';
+
+const messageRouter = () => {
+  const router = Router();
+
+  router.get(
+    '/messageListId',
+    authorizeMiddleware,
+    zodValidateMiddleware(messageListIdSchema),
+    async (req: Request, res: Response) => {
+      const { orderId, hostUserId, participantUserId } = req.body;
+      try {
+        const data = await MessageListService.getMessageListId({
+          orderId: new mongoose.Types.ObjectId(orderId),
+          hostUserId: new mongoose.Types.ObjectId(hostUserId),
+          participantUserId: new mongoose.Types.ObjectId(participantUserId),
+        });
+
+        res.status(200).send(data);
+      } catch (error) {
+        throwAPIError({ res, error, statusCode: 400 });
+      }
+    }
+  );
+
+  return router;
+};
+const messageRoute = messageRouter();
+export default messageRoute;

--- a/src/route/message-list.route.ts
+++ b/src/route/message-list.route.ts
@@ -1,5 +1,4 @@
 import { Request, Response, Router } from 'express';
-import mongoose from 'mongoose';
 import authorizeMiddleware from '../middleware/authorize.middleware';
 import { zodValidateMiddleware } from '../middleware/validate.middleware';
 import * as MessageListService from '../service/message-list.service';
@@ -17,9 +16,9 @@ const messageRouter = () => {
       const { orderId, hostUserId, participantUserId } = req.body;
       try {
         const data = await MessageListService.getMessageListId({
-          orderId: new mongoose.Types.ObjectId(orderId),
-          hostUserId: new mongoose.Types.ObjectId(hostUserId),
-          participantUserId: new mongoose.Types.ObjectId(participantUserId),
+          orderId,
+          hostUserId,
+          participantUserId,
         });
 
         res.status(200).send(data);

--- a/src/route/payment.route.ts
+++ b/src/route/payment.route.ts
@@ -59,7 +59,7 @@ const paymentRouter = () => {
         const baseParam = {
           MerchantTradeNo: TradeNo,
           MerchantTradeDate,
-          TotalAmount: payment.amount.toLocaleString(),
+          TotalAmount: payment.amount,
           TradeDesc: tradeDesc,
           ItemName: itemName,
           ReturnURL: process.env.PAYMENT_RETURN_URL,

--- a/src/route/socket.route.ts
+++ b/src/route/socket.route.ts
@@ -1,0 +1,40 @@
+import mongoose from 'mongoose';
+import { Server } from 'socket.io';
+import MessageList from '../model/message-list.model';
+import { LiveMessageParams } from '../type/message-list.type';
+
+const socketRoute = (io: Server) => {
+  console.log('socketRoute');
+  io.on('connection', async (socket) => {
+    // FIXME
+    const messageListId = new mongoose.Types.ObjectId(
+      (socket.handshake.query.messageListId as string) ?? ''
+    );
+
+    console.log('query', socket.handshake.query);
+
+    if (!messageListId) {
+      socket.disconnect(true);
+      return;
+    }
+
+    const messageList = await MessageList.findById(messageListId);
+
+    // restrict to host and participant user
+    socket.emit('history', messageList);
+
+    socket.on('chat message', async (msg) => {
+      const data = JSON.parse(msg) as LiveMessageParams;
+      await messageList?.updateOne({
+        $push: {
+          messages: data.messages,
+        },
+      });
+
+      // restrict to host and participant user
+      io.emit('chat message', messageList);
+    });
+  });
+};
+
+export default socketRoute;

--- a/src/route/socket.route.ts
+++ b/src/route/socket.route.ts
@@ -30,12 +30,12 @@ const socketRoute = (io: Server) => {
           },
         });
         await messageList?.save();
-        socket.emit('history', messageList);
+        const updatedMessageList = await MessageList.findById(messageList?._id);
+        socket.emit('history', updatedMessageList);
       } catch (error) {
         if (error instanceof ZodError) {
           socket.emit('error', zodErrorHandler(error));
         } else {
-          console.log(error);
           socket.emit('error', 'Error while sending the message');
         }
       }

--- a/src/route/userActivity.route.ts
+++ b/src/route/userActivity.route.ts
@@ -18,7 +18,9 @@ const userActivityRouter = () => {
     authorizeMiddleware,
     zodValidateMiddleware(activitySchema),
     async (req: Request, res: Response) => {
-      /* #swagger.tags = ['Activity'] */
+      /* #swagger.tags = ['Activity'] 
+          #swagger.parameters['body'] = { in: 'body', schema: { $ref: "#/schemas/ActivityCreateCredentials" }}
+      */
 
       const creatorId = req.user?._id;
       try {
@@ -38,6 +40,10 @@ const userActivityRouter = () => {
     authorizeMiddleware,
     zodValidateMiddleware(activitySchema),
     async (req: Request, res: Response) => {
+      /* #swagger.tags = ['Activity'] 
+          #swagger.parameters['body'] = { in: 'body', schema: { $ref: "#/schemas/ActivityEditCredentials" }}
+      */
+
       const userId = req.user?._id;
       try {
         const activityId = new mongoose.Types.ObjectId(req.params.activityId);

--- a/src/service/message-list.service.ts
+++ b/src/service/message-list.service.ts
@@ -1,4 +1,7 @@
+import mongoose from 'mongoose';
+import Activity from '../model/activity.model';
 import MessageList from '../model/message-list.model';
+import Order from '../model/order.model';
 import { GetMessageListParams } from '../type/message-list.type';
 import { CoreError } from '../util/error-handler';
 
@@ -16,8 +19,20 @@ export const getMessageListId = async ({
   if (hostUserId === participantUserId) {
     throw new CoreError('Host and participant cannot be the same user.');
   }
+  const orderObjectId = new mongoose.Types.ObjectId(orderId);
+  const hostUserIdObjectId = new mongoose.Types.ObjectId(hostUserId);
+  const participantUserIdObjectId = new mongoose.Types.ObjectId(
+    participantUserId
+  );
 
-  // TODO: Check if the user is the host or participant of the order
+  const order = await Order.findById(orderObjectId);
+  const activity = await Activity.findById(order?.activityId);
+  if (!order?.userId.equals(participantUserIdObjectId)) {
+    throw new CoreError("Participant doesn't same as the order user.");
+  }
+  if (!activity?.creatorId.equals(hostUserIdObjectId)) {
+    throw new CoreError("Host doesn't same as the activity creator.");
+  }
 
   try {
     if (!messageList) {

--- a/src/service/message-list.service.ts
+++ b/src/service/message-list.service.ts
@@ -1,0 +1,38 @@
+import MessageList from '../model/message-list.model';
+import { GetMessageListParams } from '../type/message-list.type';
+import { CoreError } from '../util/error-handler';
+
+export const getMessageListId = async ({
+  orderId,
+  hostUserId,
+  participantUserId,
+}: GetMessageListParams) => {
+  const messageList = await MessageList.findOne({
+    orderId,
+    hostUserId,
+    participantUserId,
+  });
+
+  if (hostUserId === participantUserId) {
+    throw new CoreError('Host and participant cannot be the same user.');
+  }
+
+  // TODO: Check if the user is the host or participant of the order
+
+  try {
+    if (!messageList) {
+      const newMessageList = new MessageList({
+        orderId,
+        hostUserId,
+        participantUserId,
+      });
+      await newMessageList.save();
+
+      return { messageListId: newMessageList._id };
+    } else {
+      return { messageListId: messageList._id };
+    }
+  } catch (error) {
+    throw new CoreError('Get message list id failed.');
+  }
+};

--- a/src/service/userActivity.service.ts
+++ b/src/service/userActivity.service.ts
@@ -5,8 +5,8 @@ import Question from '../model/question.model';
 import Ticket from '../model/ticket.model';
 import User from '../model/user.model';
 import {
-  ActivityCreateCredentials,
-  ActivityEditCredentials,
+  ActivityCreateParams,
+  ActivityEditParams,
   CancelActivityParams,
   CollectActivityParams,
   GetActivitiesParams,
@@ -22,7 +22,7 @@ import { paginator } from '../util/paginator';
 export const createActivity = async ({
   tickets,
   ...activityData
-}: ActivityCreateCredentials) => {
+}: ActivityCreateParams) => {
   try {
     const newActivity = new Activity(activityData);
     await newActivity.save();
@@ -52,7 +52,7 @@ export const editActivity = async ({
   activityId,
   tickets,
   ...activityData
-}: ActivityEditCredentials) => {
+}: ActivityEditParams) => {
   const existingActivity = await Activity.findById(activityId);
   if (!existingActivity?.creatorId.equals(userId))
     throw new CoreError('Activity cannot be edited by non-creators.');

--- a/src/swagger/build/_schema.ts
+++ b/src/swagger/build/_schema.ts
@@ -498,6 +498,68 @@ export const _schema = {
         "unlimitedQuantity"
       ]
     },
+    "EditableTicket": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "price": {
+          "type": "number"
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fromToday": {
+          "type": "boolean"
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "noEndDate": {
+          "type": "boolean"
+        },
+        "participantCapacity": {
+          "type": "number"
+        },
+        "unlimitedQuantity": {
+          "type": "boolean"
+        },
+        "purchaseLimit": {
+          "type": "number"
+        },
+        "purchaseDuplicate": {
+          "type": "boolean"
+        },
+        "ticketStatus": {
+          "type": "string",
+          "enum": [
+            "可購買",
+            "已售完",
+            "結束售票"
+          ]
+        }
+      },
+      "required": [
+        "description",
+        "endDateTime",
+        "fromToday",
+        "name",
+        "noEndDate",
+        "participantCapacity",
+        "price",
+        "purchaseDuplicate",
+        "purchaseLimit",
+        "startDateTime",
+        "ticketStatus",
+        "unlimitedQuantity"
+      ]
+    },
     "CategoryEnum": {
       "type": "string",
       "enum": [
@@ -878,7 +940,7 @@ export const _schema = {
         "type"
       ]
     },
-    "ActivityCreateCredentials": {
+    "ActivityCreateParams": {
       "type": "object",
       "properties": {
         "creatorId": {
@@ -1153,16 +1215,592 @@ export const _schema = {
         "type"
       ]
     },
-    "ActivityEditCredentials": {
+    "ActivityCreateCredentials": {
+      "type": "object",
+      "properties": {
+        "link": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "線上",
+            "室內",
+            "室外"
+          ]
+        },
+        "location": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "有效",
+            "取消",
+            "結束"
+          ]
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fromToday": {
+          "type": "boolean"
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "noEndDate": {
+          "type": "boolean"
+        },
+        "organizer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "profilePicture": {
+              "type": "string"
+            },
+            "contactName": {
+              "type": "string"
+            },
+            "contactPhone": {
+              "type": "string"
+            },
+            "contactEmail": {
+              "type": "string"
+            },
+            "websiteName": {
+              "type": "string"
+            },
+            "websiteURL": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "contactEmail",
+            "contactName",
+            "contactPhone",
+            "name",
+            "profilePicture",
+            "websiteName",
+            "websiteURL"
+          ]
+        },
+        "cover": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "戶外踏青",
+            "社交活動",
+            "興趣嗜好",
+            "運動健身",
+            "健康生活",
+            "科技玩物",
+            "藝術文化",
+            "遊戲"
+          ]
+        },
+        "isPrivate": {
+          "type": "boolean"
+        },
+        "displayRemainingTickets": {
+          "type": "boolean"
+        },
+        "isRecurring": {
+          "type": "boolean"
+        },
+        "recurring": {
+          "type": "object",
+          "properties": {
+            "period": {
+              "type": "string",
+              "enum": [
+                "隔週",
+                "每月",
+                "每季"
+              ]
+            },
+            "week": {
+              "type": "string",
+              "enum": [
+                "每週",
+                "隔週",
+                "第一週",
+                "第二週",
+                "第三週",
+                "第四週",
+                "最後一週"
+              ]
+            },
+            "day": {
+              "type": "string",
+              "enum": [
+                "星期一",
+                "星期二",
+                "星期三",
+                "星期四",
+                "星期五",
+                "星期六",
+                "星期日"
+              ]
+            }
+          },
+          "required": [
+            "day",
+            "period",
+            "week"
+          ]
+        },
+        "tickets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "activityId": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "name": {
+                "type": "string"
+              },
+              "price": {
+                "type": "number"
+              },
+              "startDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "fromToday": {
+                "type": "boolean"
+              },
+              "endDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "noEndDate": {
+                "type": "boolean"
+              },
+              "participantCapacity": {
+                "type": "number"
+              },
+              "unlimitedQuantity": {
+                "type": "boolean"
+              },
+              "purchaseLimit": {
+                "type": "number"
+              },
+              "description": {
+                "type": "string"
+              },
+              "purchaseDuplicate": {
+                "type": "boolean"
+              },
+              "ticketStatus": {
+                "type": "string",
+                "enum": [
+                  "可購買",
+                  "已售完",
+                  "結束售票"
+                ]
+              }
+            },
+            "required": [
+              "activityId",
+              "description",
+              "endDateTime",
+              "fromToday",
+              "name",
+              "noEndDate",
+              "participantCapacity",
+              "price",
+              "purchaseDuplicate",
+              "purchaseLimit",
+              "startDateTime",
+              "ticketStatus",
+              "unlimitedQuantity"
+            ]
+          }
+        },
+        "questions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QuestionSchemaModel"
+          }
+        },
+        "lat": {
+          "type": "string"
+        },
+        "lng": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "category",
+        "cover",
+        "details",
+        "displayRemainingTickets",
+        "endDateTime",
+        "fromToday",
+        "isPrivate",
+        "isRecurring",
+        "lat",
+        "link",
+        "lng",
+        "location",
+        "name",
+        "noEndDate",
+        "organizer",
+        "questions",
+        "recurring",
+        "startDateTime",
+        "status",
+        "summary",
+        "thumbnail",
+        "tickets",
+        "type"
+      ]
+    },
+    "EditableActivity": {
+      "type": "object",
+      "properties": {
+        "link": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "線上",
+            "室內",
+            "室外"
+          ]
+        },
+        "location": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "有效",
+            "取消",
+            "結束"
+          ]
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fromToday": {
+          "type": "boolean"
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "noEndDate": {
+          "type": "boolean"
+        },
+        "organizer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "profilePicture": {
+              "type": "string"
+            },
+            "contactName": {
+              "type": "string"
+            },
+            "contactPhone": {
+              "type": "string"
+            },
+            "contactEmail": {
+              "type": "string"
+            },
+            "websiteName": {
+              "type": "string"
+            },
+            "websiteURL": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "contactEmail",
+            "contactName",
+            "contactPhone",
+            "name",
+            "profilePicture",
+            "websiteName",
+            "websiteURL"
+          ]
+        },
+        "cover": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "戶外踏青",
+            "社交活動",
+            "興趣嗜好",
+            "運動健身",
+            "健康生活",
+            "科技玩物",
+            "藝術文化",
+            "遊戲"
+          ]
+        },
+        "isPrivate": {
+          "type": "boolean"
+        },
+        "displayRemainingTickets": {
+          "type": "boolean"
+        },
+        "isRecurring": {
+          "type": "boolean"
+        },
+        "recurring": {
+          "type": "object",
+          "properties": {
+            "period": {
+              "type": "string",
+              "enum": [
+                "線下",
+                "線上"
+              ]
+            },
+            "week": {
+              "type": "string",
+              "enum": [
+                "每週",
+                "隔週",
+                "第一週",
+                "第二週",
+                "第三週",
+                "第四週",
+                "最後一週"
+              ]
+            },
+            "day": {
+              "type": "string",
+              "enum": [
+                "星期一",
+                "星期二",
+                "星期三",
+                "星期四",
+                "星期五",
+                "星期六",
+                "星期日"
+              ]
+            }
+          },
+          "required": [
+            "day",
+            "period",
+            "week"
+          ]
+        },
+        "tickets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "activityId": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "name": {
+                "type": "string"
+              },
+              "price": {
+                "type": "number"
+              },
+              "startDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "fromToday": {
+                "type": "boolean"
+              },
+              "endDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "noEndDate": {
+                "type": "boolean"
+              },
+              "participantCapacity": {
+                "type": "number"
+              },
+              "unlimitedQuantity": {
+                "type": "boolean"
+              },
+              "purchaseLimit": {
+                "type": "number"
+              },
+              "description": {
+                "type": "string"
+              },
+              "purchaseDuplicate": {
+                "type": "boolean"
+              },
+              "ticketStatus": {
+                "type": "string",
+                "enum": [
+                  "可購買",
+                  "已售完",
+                  "結束售票"
+                ]
+              }
+            },
+            "required": [
+              "activityId",
+              "description",
+              "endDateTime",
+              "fromToday",
+              "name",
+              "noEndDate",
+              "participantCapacity",
+              "price",
+              "purchaseDuplicate",
+              "purchaseLimit",
+              "startDateTime",
+              "ticketStatus",
+              "unlimitedQuantity"
+            ]
+          }
+        },
+        "lat": {
+          "type": "string"
+        },
+        "lng": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "category",
+        "cover",
+        "details",
+        "displayRemainingTickets",
+        "endDateTime",
+        "fromToday",
+        "isPrivate",
+        "isRecurring",
+        "lat",
+        "link",
+        "lng",
+        "location",
+        "name",
+        "noEndDate",
+        "organizer",
+        "recurring",
+        "startDateTime",
+        "status",
+        "summary",
+        "thumbnail",
+        "tickets",
+        "type"
+      ]
+    },
+    "ActivityEditParams": {
       "allOf": [
         {
           "type": "object",
           "properties": {
-            "creatorId": {
-              "$ref": "#/definitions/Types.ObjectId"
+            "link": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "線上",
+                "室內",
+                "室外"
+              ]
+            },
+            "location": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
             },
             "name": {
               "type": "string"
+            },
+            "details": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "有效",
+                "取消",
+                "結束"
+              ]
+            },
+            "startDateTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "fromToday": {
+              "type": "boolean"
+            },
+            "endDateTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "noEndDate": {
+              "type": "boolean"
             },
             "organizer": {
               "type": "object",
@@ -1208,20 +1846,6 @@ export const _schema = {
             "thumbnail": {
               "type": "string"
             },
-            "startDateTime": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "fromToday": {
-              "type": "boolean"
-            },
-            "endDateTime": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "noEndDate": {
-              "type": "boolean"
-            },
             "category": {
               "type": "string",
               "enum": [
@@ -1234,29 +1858,6 @@ export const _schema = {
                 "藝術文化",
                 "遊戲"
               ]
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "線上",
-                "室內",
-                "室外"
-              ]
-            },
-            "link": {
-              "type": "string"
-            },
-            "location": {
-              "type": "string"
-            },
-            "address": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "details": {
-              "type": "string"
             },
             "isPrivate": {
               "type": "boolean"
@@ -1307,14 +1908,6 @@ export const _schema = {
                 "day",
                 "period",
                 "week"
-              ]
-            },
-            "status": {
-              "type": "string",
-              "enum": [
-                "有效",
-                "取消",
-                "結束"
               ]
             },
             "tickets": {
@@ -1394,19 +1987,12 @@ export const _schema = {
               "items": {
                 "$ref": "#/definitions/QuestionSchemaModel"
               }
-            },
-            "lat": {
-              "type": "string"
-            },
-            "lng": {
-              "type": "string"
             }
           },
           "required": [
             "address",
             "category",
             "cover",
-            "creatorId",
             "details",
             "displayRemainingTickets",
             "endDateTime",
@@ -1420,7 +2006,6 @@ export const _schema = {
             "name",
             "noEndDate",
             "organizer",
-            "questions",
             "recurring",
             "startDateTime",
             "status",
@@ -1445,6 +2030,270 @@ export const _schema = {
             "userId"
           ]
         }
+      ]
+    },
+    "ActivityEditCredentials": {
+      "type": "object",
+      "properties": {
+        "link": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "線上",
+            "室內",
+            "室外"
+          ]
+        },
+        "location": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "有效",
+            "取消",
+            "結束"
+          ]
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fromToday": {
+          "type": "boolean"
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "noEndDate": {
+          "type": "boolean"
+        },
+        "organizer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "profilePicture": {
+              "type": "string"
+            },
+            "contactName": {
+              "type": "string"
+            },
+            "contactPhone": {
+              "type": "string"
+            },
+            "contactEmail": {
+              "type": "string"
+            },
+            "websiteName": {
+              "type": "string"
+            },
+            "websiteURL": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "contactEmail",
+            "contactName",
+            "contactPhone",
+            "name",
+            "profilePicture",
+            "websiteName",
+            "websiteURL"
+          ]
+        },
+        "cover": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "戶外踏青",
+            "社交活動",
+            "興趣嗜好",
+            "運動健身",
+            "健康生活",
+            "科技玩物",
+            "藝術文化",
+            "遊戲"
+          ]
+        },
+        "isPrivate": {
+          "type": "boolean"
+        },
+        "displayRemainingTickets": {
+          "type": "boolean"
+        },
+        "isRecurring": {
+          "type": "boolean"
+        },
+        "recurring": {
+          "type": "object",
+          "properties": {
+            "period": {
+              "type": "string",
+              "enum": [
+                "隔週",
+                "每月",
+                "每季"
+              ]
+            },
+            "week": {
+              "type": "string",
+              "enum": [
+                "每週",
+                "隔週",
+                "第一週",
+                "第二週",
+                "第三週",
+                "第四週",
+                "最後一週"
+              ]
+            },
+            "day": {
+              "type": "string",
+              "enum": [
+                "星期一",
+                "星期二",
+                "星期三",
+                "星期四",
+                "星期五",
+                "星期六",
+                "星期日"
+              ]
+            }
+          },
+          "required": [
+            "day",
+            "period",
+            "week"
+          ]
+        },
+        "tickets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "activityId": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "name": {
+                "type": "string"
+              },
+              "price": {
+                "type": "number"
+              },
+              "startDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "fromToday": {
+                "type": "boolean"
+              },
+              "endDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "noEndDate": {
+                "type": "boolean"
+              },
+              "participantCapacity": {
+                "type": "number"
+              },
+              "unlimitedQuantity": {
+                "type": "boolean"
+              },
+              "purchaseLimit": {
+                "type": "number"
+              },
+              "description": {
+                "type": "string"
+              },
+              "purchaseDuplicate": {
+                "type": "boolean"
+              },
+              "ticketStatus": {
+                "type": "string",
+                "enum": [
+                  "可購買",
+                  "已售完",
+                  "結束售票"
+                ]
+              }
+            },
+            "required": [
+              "activityId",
+              "description",
+              "endDateTime",
+              "fromToday",
+              "name",
+              "noEndDate",
+              "participantCapacity",
+              "price",
+              "purchaseDuplicate",
+              "purchaseLimit",
+              "startDateTime",
+              "ticketStatus",
+              "unlimitedQuantity"
+            ]
+          }
+        },
+        "lat": {
+          "type": "string"
+        },
+        "lng": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "category",
+        "cover",
+        "details",
+        "displayRemainingTickets",
+        "endDateTime",
+        "fromToday",
+        "isPrivate",
+        "isRecurring",
+        "lat",
+        "link",
+        "lng",
+        "location",
+        "name",
+        "noEndDate",
+        "organizer",
+        "recurring",
+        "startDateTime",
+        "status",
+        "summary",
+        "thumbnail",
+        "tickets",
+        "type"
       ]
     },
     "GetActivitiesParams": {
@@ -1617,56 +2466,6 @@ export const _schema = {
           "type": "number"
         }
       }
-    },
-    "ImageFile": {
-      "type": "object",
-      "properties": {
-        "fieldname": {
-          "type": "string"
-        },
-        "originalname": {
-          "type": "string"
-        },
-        "encoding": {
-          "type": "string"
-        },
-        "mimetype": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "size": {
-          "type": "number"
-        },
-        "filename": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "encoding",
-        "fieldname",
-        "filename",
-        "mimetype",
-        "originalname",
-        "path",
-        "size"
-      ]
-    },
-    "KeywordSchemaModel": {
-      "type": "object",
-      "properties": {
-        "content": {
-          "type": "string"
-        },
-        "count": {
-          "type": "number"
-        }
-      },
-      "required": [
-        "content",
-        "count"
-      ]
     },
     "PaymentStatusEnum": {
       "type": "string",

--- a/src/swagger/build/_schema.ts
+++ b/src/swagger/build/_schema.ts
@@ -1609,8 +1609,9 @@ export const _schema = {
             "period": {
               "type": "string",
               "enum": [
-                "線下",
-                "線上"
+                "隔週",
+                "每月",
+                "每季"
               ]
             },
             "week": {
@@ -1982,11 +1983,11 @@ export const _schema = {
                 ]
               }
             },
-            "questions": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/QuestionSchemaModel"
-              }
+            "lat": {
+              "type": "string"
+            },
+            "lng": {
+              "type": "string"
             }
           },
           "required": [
@@ -2467,6 +2468,196 @@ export const _schema = {
         }
       }
     },
+    "ImageFile": {
+      "type": "object",
+      "properties": {
+        "fieldname": {
+          "type": "string"
+        },
+        "originalname": {
+          "type": "string"
+        },
+        "encoding": {
+          "type": "string"
+        },
+        "mimetype": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "size": {
+          "type": "number"
+        },
+        "filename": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "encoding",
+        "fieldname",
+        "filename",
+        "mimetype",
+        "originalname",
+        "path",
+        "size"
+      ]
+    },
+    "KeywordSchemaModel": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "content",
+        "count"
+      ]
+    },
+    "MessageUserType": {
+      "type": "string",
+      "enum": [
+        "舉辦者",
+        "參加者"
+      ]
+    },
+    "MessageSchemaModel": {
+      "type": "object",
+      "properties": {
+        "userType": {
+          "type": "string",
+          "enum": [
+            "舉辦者",
+            "參加者"
+          ]
+        },
+        "content": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "userType"
+      ]
+    },
+    "MessageListSchemaModel": {
+      "type": "object",
+      "properties": {
+        "orderId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "hostUserId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "participantUserId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "userType": {
+                "type": "string",
+                "enum": [
+                  "舉辦者",
+                  "參加者"
+                ]
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "content",
+              "userType"
+            ]
+          }
+        }
+      },
+      "required": [
+        "hostUserId",
+        "messages",
+        "orderId",
+        "participantUserId"
+      ]
+    },
+    "GetMessageListParams": {
+      "type": "object",
+      "properties": {
+        "orderId": {
+          "type": "string"
+        },
+        "hostUserId": {
+          "type": "string"
+        },
+        "participantUserId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "hostUserId",
+        "orderId",
+        "participantUserId"
+      ]
+    },
+    "LiveMessageParams": {
+      "type": "object",
+      "properties": {
+        "orderId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "hostUserId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "participantUserId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "userType": {
+                "type": "string",
+                "enum": [
+                  "舉辦者",
+                  "參加者"
+                ]
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "content",
+              "userType"
+            ]
+          }
+        }
+      },
+      "required": [
+        "hostUserId",
+        "messages",
+        "orderId",
+        "participantUserId"
+      ]
+    },
+    "SocketQueryParams": {
+      "type": "object",
+      "properties": {
+        "messageListId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "messageListId"
+      ]
+    },
     "PaymentStatusEnum": {
       "type": "string",
       "enum": [
@@ -2533,7 +2724,7 @@ export const _schema = {
       "type": "object",
       "properties": {
         "amount": {
-          "type": "number"
+          "type": "string"
         },
         "status": {
           "enum": [
@@ -2612,7 +2803,7 @@ export const _schema = {
           "type": "object",
           "properties": {
             "amount": {
-              "type": "number"
+              "type": "string"
             },
             "status": {
               "enum": [
@@ -2722,7 +2913,7 @@ export const _schema = {
               "type": "object",
               "properties": {
                 "amount": {
-                  "type": "number"
+                  "type": "string"
                 },
                 "status": {
                   "enum": [
@@ -2863,7 +3054,7 @@ export const _schema = {
               "type": "object",
               "properties": {
                 "amount": {
-                  "type": "number"
+                  "type": "string"
                 },
                 "status": {
                   "enum": [

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -19,7 +19,7 @@
   "paths": {
     "/api/demo": {
       "get": {
-        "description": "",
+        "description": "Validate all of users",
         "responses": {
           "200": {
             "description": "OK"
@@ -63,26 +63,6 @@
         "responses": {
           "200": {
             "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/google-oauth": {
-      "get": {
-        "description": "",
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/api/google-oauth/callback": {
-      "get": {
-        "description": "",
-        "responses": {
-          "default": {
-            "description": ""
           }
         }
       }
@@ -256,6 +236,15 @@
       "post": {
         "tags": ["Activity"],
         "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/schemas/ActivityCreateCredentials"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -305,6 +294,7 @@
     },
     "/api/auth/activities/{activityId}": {
       "put": {
+        "tags": ["Activity"],
         "description": "",
         "parameters": [
           {
@@ -312,6 +302,13 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/schemas/ActivityEditCredentials"
+            }
           }
         ],
         "responses": {
@@ -646,6 +643,31 @@
             "in": "body",
             "schema": {
               "$ref": "#/schemas/TriggerPaymentCredentials"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/api/auth/messageListId": {
+      "get": {
+        "tags": ["MessageList"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/schemas/GetMessageListParams"
             }
           }
         ],
@@ -1080,6 +1102,64 @@
         "unlimitedQuantity"
       ]
     },
+    "EditableTicket": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "price": {
+          "type": "number"
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fromToday": {
+          "type": "boolean"
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "noEndDate": {
+          "type": "boolean"
+        },
+        "participantCapacity": {
+          "type": "number"
+        },
+        "unlimitedQuantity": {
+          "type": "boolean"
+        },
+        "purchaseLimit": {
+          "type": "number"
+        },
+        "purchaseDuplicate": {
+          "type": "boolean"
+        },
+        "ticketStatus": {
+          "type": "string",
+          "enum": ["可購買", "已售完", "結束售票"]
+        }
+      },
+      "required": [
+        "description",
+        "endDateTime",
+        "fromToday",
+        "name",
+        "noEndDate",
+        "participantCapacity",
+        "price",
+        "purchaseDuplicate",
+        "purchaseLimit",
+        "startDateTime",
+        "ticketStatus",
+        "unlimitedQuantity"
+      ]
+    },
     "CategoryEnum": {
       "type": "string",
       "enum": [
@@ -1418,7 +1498,7 @@
         "type"
       ]
     },
-    "ActivityCreateCredentials": {
+    "ActivityCreateParams": {
       "type": "object",
       "properties": {
         "creatorId": {
@@ -1673,16 +1753,546 @@
         "type"
       ]
     },
-    "ActivityEditCredentials": {
+    "ActivityCreateCredentials": {
+      "type": "object",
+      "properties": {
+        "link": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["線上", "室內", "室外"]
+        },
+        "location": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["有效", "取消", "結束"]
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fromToday": {
+          "type": "boolean"
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "noEndDate": {
+          "type": "boolean"
+        },
+        "organizer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "profilePicture": {
+              "type": "string"
+            },
+            "contactName": {
+              "type": "string"
+            },
+            "contactPhone": {
+              "type": "string"
+            },
+            "contactEmail": {
+              "type": "string"
+            },
+            "websiteName": {
+              "type": "string"
+            },
+            "websiteURL": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "contactEmail",
+            "contactName",
+            "contactPhone",
+            "name",
+            "profilePicture",
+            "websiteName",
+            "websiteURL"
+          ]
+        },
+        "cover": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "戶外踏青",
+            "社交活動",
+            "興趣嗜好",
+            "運動健身",
+            "健康生活",
+            "科技玩物",
+            "藝術文化",
+            "遊戲"
+          ]
+        },
+        "isPrivate": {
+          "type": "boolean"
+        },
+        "displayRemainingTickets": {
+          "type": "boolean"
+        },
+        "isRecurring": {
+          "type": "boolean"
+        },
+        "recurring": {
+          "type": "object",
+          "properties": {
+            "period": {
+              "type": "string",
+              "enum": ["隔週", "每月", "每季"]
+            },
+            "week": {
+              "type": "string",
+              "enum": [
+                "每週",
+                "隔週",
+                "第一週",
+                "第二週",
+                "第三週",
+                "第四週",
+                "最後一週"
+              ]
+            },
+            "day": {
+              "type": "string",
+              "enum": [
+                "星期一",
+                "星期二",
+                "星期三",
+                "星期四",
+                "星期五",
+                "星期六",
+                "星期日"
+              ]
+            }
+          },
+          "required": ["day", "period", "week"]
+        },
+        "tickets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "activityId": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "name": {
+                "type": "string"
+              },
+              "price": {
+                "type": "number"
+              },
+              "startDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "fromToday": {
+                "type": "boolean"
+              },
+              "endDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "noEndDate": {
+                "type": "boolean"
+              },
+              "participantCapacity": {
+                "type": "number"
+              },
+              "unlimitedQuantity": {
+                "type": "boolean"
+              },
+              "purchaseLimit": {
+                "type": "number"
+              },
+              "description": {
+                "type": "string"
+              },
+              "purchaseDuplicate": {
+                "type": "boolean"
+              },
+              "ticketStatus": {
+                "type": "string",
+                "enum": ["可購買", "已售完", "結束售票"]
+              }
+            },
+            "required": [
+              "activityId",
+              "description",
+              "endDateTime",
+              "fromToday",
+              "name",
+              "noEndDate",
+              "participantCapacity",
+              "price",
+              "purchaseDuplicate",
+              "purchaseLimit",
+              "startDateTime",
+              "ticketStatus",
+              "unlimitedQuantity"
+            ]
+          }
+        },
+        "questions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QuestionSchemaModel"
+          }
+        },
+        "lat": {
+          "type": "string"
+        },
+        "lng": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "category",
+        "cover",
+        "details",
+        "displayRemainingTickets",
+        "endDateTime",
+        "fromToday",
+        "isPrivate",
+        "isRecurring",
+        "lat",
+        "link",
+        "lng",
+        "location",
+        "name",
+        "noEndDate",
+        "organizer",
+        "questions",
+        "recurring",
+        "startDateTime",
+        "status",
+        "summary",
+        "thumbnail",
+        "tickets",
+        "type"
+      ]
+    },
+    "EditableActivity": {
+      "type": "object",
+      "properties": {
+        "link": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["線上", "室內", "室外"]
+        },
+        "location": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["有效", "取消", "結束"]
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fromToday": {
+          "type": "boolean"
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "noEndDate": {
+          "type": "boolean"
+        },
+        "organizer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "profilePicture": {
+              "type": "string"
+            },
+            "contactName": {
+              "type": "string"
+            },
+            "contactPhone": {
+              "type": "string"
+            },
+            "contactEmail": {
+              "type": "string"
+            },
+            "websiteName": {
+              "type": "string"
+            },
+            "websiteURL": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "contactEmail",
+            "contactName",
+            "contactPhone",
+            "name",
+            "profilePicture",
+            "websiteName",
+            "websiteURL"
+          ]
+        },
+        "cover": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "戶外踏青",
+            "社交活動",
+            "興趣嗜好",
+            "運動健身",
+            "健康生活",
+            "科技玩物",
+            "藝術文化",
+            "遊戲"
+          ]
+        },
+        "isPrivate": {
+          "type": "boolean"
+        },
+        "displayRemainingTickets": {
+          "type": "boolean"
+        },
+        "isRecurring": {
+          "type": "boolean"
+        },
+        "recurring": {
+          "type": "object",
+          "properties": {
+            "period": {
+              "type": "string",
+              "enum": ["隔週", "每月", "每季"]
+            },
+            "week": {
+              "type": "string",
+              "enum": [
+                "每週",
+                "隔週",
+                "第一週",
+                "第二週",
+                "第三週",
+                "第四週",
+                "最後一週"
+              ]
+            },
+            "day": {
+              "type": "string",
+              "enum": [
+                "星期一",
+                "星期二",
+                "星期三",
+                "星期四",
+                "星期五",
+                "星期六",
+                "星期日"
+              ]
+            }
+          },
+          "required": ["day", "period", "week"]
+        },
+        "tickets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "activityId": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "name": {
+                "type": "string"
+              },
+              "price": {
+                "type": "number"
+              },
+              "startDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "fromToday": {
+                "type": "boolean"
+              },
+              "endDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "noEndDate": {
+                "type": "boolean"
+              },
+              "participantCapacity": {
+                "type": "number"
+              },
+              "unlimitedQuantity": {
+                "type": "boolean"
+              },
+              "purchaseLimit": {
+                "type": "number"
+              },
+              "description": {
+                "type": "string"
+              },
+              "purchaseDuplicate": {
+                "type": "boolean"
+              },
+              "ticketStatus": {
+                "type": "string",
+                "enum": ["可購買", "已售完", "結束售票"]
+              }
+            },
+            "required": [
+              "activityId",
+              "description",
+              "endDateTime",
+              "fromToday",
+              "name",
+              "noEndDate",
+              "participantCapacity",
+              "price",
+              "purchaseDuplicate",
+              "purchaseLimit",
+              "startDateTime",
+              "ticketStatus",
+              "unlimitedQuantity"
+            ]
+          }
+        },
+        "lat": {
+          "type": "string"
+        },
+        "lng": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "category",
+        "cover",
+        "details",
+        "displayRemainingTickets",
+        "endDateTime",
+        "fromToday",
+        "isPrivate",
+        "isRecurring",
+        "lat",
+        "link",
+        "lng",
+        "location",
+        "name",
+        "noEndDate",
+        "organizer",
+        "questions",
+        "recurring",
+        "startDateTime",
+        "status",
+        "summary",
+        "thumbnail",
+        "tickets",
+        "type"
+      ]
+    },
+    "ActivityEditParams": {
       "allOf": [
         {
           "type": "object",
           "properties": {
-            "creatorId": {
-              "$ref": "#/definitions/Types.ObjectId"
+            "link": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": ["線上", "室內", "室外"]
+            },
+            "location": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
             },
             "name": {
               "type": "string"
+            },
+            "details": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": ["有效", "取消", "結束"]
+            },
+            "startDateTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "fromToday": {
+              "type": "boolean"
+            },
+            "endDateTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "noEndDate": {
+              "type": "boolean"
             },
             "organizer": {
               "type": "object",
@@ -1728,20 +2338,6 @@
             "thumbnail": {
               "type": "string"
             },
-            "startDateTime": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "fromToday": {
-              "type": "boolean"
-            },
-            "endDateTime": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "noEndDate": {
-              "type": "boolean"
-            },
             "category": {
               "type": "string",
               "enum": [
@@ -1754,25 +2350,6 @@
                 "藝術文化",
                 "遊戲"
               ]
-            },
-            "type": {
-              "type": "string",
-              "enum": ["線上", "室內", "室外"]
-            },
-            "link": {
-              "type": "string"
-            },
-            "location": {
-              "type": "string"
-            },
-            "address": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "details": {
-              "type": "string"
             },
             "isPrivate": {
               "type": "boolean"
@@ -1816,10 +2393,6 @@
                 }
               },
               "required": ["day", "period", "week"]
-            },
-            "status": {
-              "type": "string",
-              "enum": ["有效", "取消", "結束"]
             },
             "tickets": {
               "type": "array",
@@ -1889,12 +2462,6 @@
                 ]
               }
             },
-            "questions": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/QuestionSchemaModel"
-              }
-            },
             "lat": {
               "type": "string"
             },
@@ -1906,7 +2473,6 @@
             "address",
             "category",
             "cover",
-            "creatorId",
             "details",
             "displayRemainingTickets",
             "endDateTime",
@@ -1942,6 +2508,250 @@
           },
           "required": ["activityId", "userId"]
         }
+      ]
+    },
+    "ActivityEditCredentials": {
+      "type": "object",
+      "properties": {
+        "link": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["線上", "室內", "室外"]
+        },
+        "location": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["有效", "取消", "結束"]
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fromToday": {
+          "type": "boolean"
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "noEndDate": {
+          "type": "boolean"
+        },
+        "organizer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "profilePicture": {
+              "type": "string"
+            },
+            "contactName": {
+              "type": "string"
+            },
+            "contactPhone": {
+              "type": "string"
+            },
+            "contactEmail": {
+              "type": "string"
+            },
+            "websiteName": {
+              "type": "string"
+            },
+            "websiteURL": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "contactEmail",
+            "contactName",
+            "contactPhone",
+            "name",
+            "profilePicture",
+            "websiteName",
+            "websiteURL"
+          ]
+        },
+        "cover": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "戶外踏青",
+            "社交活動",
+            "興趣嗜好",
+            "運動健身",
+            "健康生活",
+            "科技玩物",
+            "藝術文化",
+            "遊戲"
+          ]
+        },
+        "isPrivate": {
+          "type": "boolean"
+        },
+        "displayRemainingTickets": {
+          "type": "boolean"
+        },
+        "isRecurring": {
+          "type": "boolean"
+        },
+        "recurring": {
+          "type": "object",
+          "properties": {
+            "period": {
+              "type": "string",
+              "enum": ["隔週", "每月", "每季"]
+            },
+            "week": {
+              "type": "string",
+              "enum": [
+                "每週",
+                "隔週",
+                "第一週",
+                "第二週",
+                "第三週",
+                "第四週",
+                "最後一週"
+              ]
+            },
+            "day": {
+              "type": "string",
+              "enum": [
+                "星期一",
+                "星期二",
+                "星期三",
+                "星期四",
+                "星期五",
+                "星期六",
+                "星期日"
+              ]
+            }
+          },
+          "required": ["day", "period", "week"]
+        },
+        "tickets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "activityId": {
+                "$ref": "#/definitions/Types.ObjectId"
+              },
+              "name": {
+                "type": "string"
+              },
+              "price": {
+                "type": "number"
+              },
+              "startDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "fromToday": {
+                "type": "boolean"
+              },
+              "endDateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "noEndDate": {
+                "type": "boolean"
+              },
+              "participantCapacity": {
+                "type": "number"
+              },
+              "unlimitedQuantity": {
+                "type": "boolean"
+              },
+              "purchaseLimit": {
+                "type": "number"
+              },
+              "description": {
+                "type": "string"
+              },
+              "purchaseDuplicate": {
+                "type": "boolean"
+              },
+              "ticketStatus": {
+                "type": "string",
+                "enum": ["可購買", "已售完", "結束售票"]
+              }
+            },
+            "required": [
+              "activityId",
+              "description",
+              "endDateTime",
+              "fromToday",
+              "name",
+              "noEndDate",
+              "participantCapacity",
+              "price",
+              "purchaseDuplicate",
+              "purchaseLimit",
+              "startDateTime",
+              "ticketStatus",
+              "unlimitedQuantity"
+            ]
+          }
+        },
+        "lat": {
+          "type": "string"
+        },
+        "lng": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "category",
+        "cover",
+        "details",
+        "displayRemainingTickets",
+        "endDateTime",
+        "fromToday",
+        "isPrivate",
+        "isRecurring",
+        "lat",
+        "link",
+        "lng",
+        "location",
+        "name",
+        "noEndDate",
+        "organizer",
+        "recurring",
+        "startDateTime",
+        "status",
+        "summary",
+        "thumbnail",
+        "tickets",
+        "type"
       ]
     },
     "GetActivitiesParams": {
@@ -2119,6 +2929,109 @@
         "path",
         "size"
       ]
+    },
+    "MessageUserType": {
+      "type": "string",
+      "enum": ["舉辦者", "參加者"]
+    },
+    "MessageSchemaModel": {
+      "type": "object",
+      "properties": {
+        "userType": {
+          "type": "string",
+          "enum": ["舉辦者", "參加者"]
+        },
+        "content": {
+          "type": "string"
+        }
+      },
+      "required": ["content", "userType"]
+    },
+    "MessageListSchemaModel": {
+      "type": "object",
+      "properties": {
+        "orderId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "hostUserId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "participantUserId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "userType": {
+                "type": "string",
+                "enum": ["舉辦者", "參加者"]
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": ["content", "userType"]
+          }
+        }
+      },
+      "required": ["hostUserId", "messages", "orderId", "participantUserId"]
+    },
+    "GetMessageListParams": {
+      "type": "object",
+      "properties": {
+        "orderId": {
+          "type": "string"
+        },
+        "hostUserId": {
+          "type": "string"
+        },
+        "participantUserId": {
+          "type": "string"
+        }
+      },
+      "required": ["hostUserId", "orderId", "participantUserId"]
+    },
+    "LiveMessageParams": {
+      "type": "object",
+      "properties": {
+        "orderId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "hostUserId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "participantUserId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "userType": {
+                "type": "string",
+                "enum": ["舉辦者", "參加者"]
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": ["content", "userType"]
+          }
+        }
+      },
+      "required": ["hostUserId", "messages", "orderId", "participantUserId"]
+    },
+    "SocketQueryParams": {
+      "type": "object",
+      "properties": {
+        "messageListId": {
+          "type": "string"
+        }
+      },
+      "required": ["messageListId"]
     },
     "PaymentStatusEnum": {
       "type": "string",

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -114,6 +114,17 @@
         }
       }
     },
+    "/api/activities/popular-keywords": {
+      "get": {
+        "tags": ["Activity"],
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/activities/{activityId}": {
       "get": {
         "tags": ["Activity"],
@@ -2239,7 +2250,6 @@
         "name",
         "noEndDate",
         "organizer",
-        "questions",
         "recurring",
         "startDateTime",
         "status",
@@ -2486,7 +2496,6 @@
             "name",
             "noEndDate",
             "organizer",
-            "questions",
             "recurring",
             "startDateTime",
             "status",
@@ -2930,6 +2939,18 @@
         "size"
       ]
     },
+    "KeywordSchemaModel": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      },
+      "required": ["content", "count"]
+    },
     "MessageUserType": {
       "type": "string",
       "enum": ["舉辦者", "參加者"]
@@ -3085,7 +3106,7 @@
       "type": "object",
       "properties": {
         "amount": {
-          "type": "number"
+          "type": "string"
         },
         "status": {
           "enum": ["付款失敗", "已付款", "待付款"],
@@ -3153,7 +3174,7 @@
           "type": "object",
           "properties": {
             "amount": {
-              "type": "number"
+              "type": "string"
             },
             "status": {
               "enum": ["付款失敗", "已付款", "待付款"],
@@ -3246,7 +3267,7 @@
               "type": "object",
               "properties": {
                 "amount": {
-                  "type": "number"
+                  "type": "string"
                 },
                 "status": {
                   "enum": ["付款失敗", "已付款", "待付款"],
@@ -3364,7 +3385,7 @@
               "type": "object",
               "properties": {
                 "amount": {
-                  "type": "number"
+                  "type": "string"
                 },
                 "status": {
                   "enum": ["付款失敗", "已付款", "待付款"],

--- a/src/type/activity.type.ts
+++ b/src/type/activity.type.ts
@@ -95,12 +95,17 @@ export interface ActivitySchemaModel {
   lng: string;
 }
 
-export type ActivityCreateCredentials = ActivitySchemaModel;
+export type ActivityCreateParams = ActivitySchemaModel;
+export type ActivityCreateCredentials = Omit<ActivitySchemaModel, 'creatorId'>;
 
-export type ActivityEditCredentials = ActivityCreateCredentials & {
+type EditableActivity = Omit<ActivitySchemaModel, 'creatorId' | 'questions'>;
+
+export type ActivityEditParams = EditableActivity & {
   userId: mongoose.Types.ObjectId | undefined;
   activityId: mongoose.Types.ObjectId;
 };
+
+export type ActivityEditCredentials = EditableActivity;
 
 export type GetActivitiesParams = {
   userId: mongoose.Types.ObjectId | undefined;

--- a/src/type/message-list.type.ts
+++ b/src/type/message-list.type.ts
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose';
+
+export enum MessageUserType {
+  HOST = '舉辦者',
+  PARTICIPANT = '參加者',
+}
+
+export interface MessageSchemaModel {
+  userType: MessageUserType;
+  content: string;
+}
+
+export interface MessageListSchemaModel {
+  orderId: mongoose.Types.ObjectId;
+  hostUserId: mongoose.Types.ObjectId;
+  participantUserId: mongoose.Types.ObjectId;
+  messages: MessageSchemaModel[];
+}
+
+export type GetMessageListParams = {
+  orderId: mongoose.Types.ObjectId;
+  hostUserId: mongoose.Types.ObjectId;
+  participantUserId: mongoose.Types.ObjectId;
+};
+
+export type LiveMessageParams = MessageListSchemaModel;

--- a/src/type/message-list.type.ts
+++ b/src/type/message-list.type.ts
@@ -18,9 +18,13 @@ export interface MessageListSchemaModel {
 }
 
 export type GetMessageListParams = {
-  orderId: mongoose.Types.ObjectId;
-  hostUserId: mongoose.Types.ObjectId;
-  participantUserId: mongoose.Types.ObjectId;
+  orderId: string;
+  hostUserId: string;
+  participantUserId: string;
 };
 
 export type LiveMessageParams = MessageListSchemaModel;
+
+export type SocketQueryParams = {
+  messageListId: string;
+};

--- a/src/type/order.type.ts
+++ b/src/type/order.type.ts
@@ -45,7 +45,7 @@ export type OrderContact = {
 };
 
 export type OrderPayment = {
-  amount: number;
+  amount: string;
   status?: PaymentStatusEnum;
   type?: PaymentTypeEnum;
   orderNumber: number;

--- a/src/type/ticket.type.ts
+++ b/src/type/ticket.type.ts
@@ -22,3 +22,5 @@ export interface TicketSchemaModel {
   purchaseDuplicate: boolean;
   ticketStatus: TicketStatusEnum;
 }
+
+export type EditableTicket = Omit<TicketSchemaModel, '_id' | 'activityId'>;

--- a/src/util/zod/message-list.schema.ts
+++ b/src/util/zod/message-list.schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const messageListIdSchema = z.object({
+  orderId: z.string({ required_error: 'Activity id is required' }),
+  hostUserId: z.string({ required_error: 'Activity id is required' }),
+  participantUserId: z.string({ required_error: 'Activity id is required' }),
+});

--- a/src/util/zod/message-list.schema.ts
+++ b/src/util/zod/message-list.schema.ts
@@ -1,7 +1,15 @@
 import { z } from 'zod';
+import { MessageUserType } from '../../type/message-list.type';
 
 export const messageListIdSchema = z.object({
   orderId: z.string({ required_error: 'Activity id is required' }),
   hostUserId: z.string({ required_error: 'Activity id is required' }),
   participantUserId: z.string({ required_error: 'Activity id is required' }),
+});
+
+export const messageSchema = z.object({
+  content: z.string({ required_error: 'Content is required' }),
+  userType: z.nativeEnum(MessageUserType, {
+    required_error: 'User type is required',
+  }),
 });

--- a/src/util/zod/payment.schema.ts
+++ b/src/util/zod/payment.schema.ts
@@ -17,7 +17,9 @@ export const paymentCheckoutSchema = z.object({
       .refine((value) => validateInt(value), 'Not a number'),
   }),
   payment: z.object({
-    amount: z.number({ required_error: 'Amount is required' }),
+    amount: z
+      .string({ required_error: 'Amount is required' })
+      .refine((value) => validateInt(value), 'Not a number'),
     status: z.nativeEnum(PaymentStatusEnum).optional(),
     type: z.nativeEnum(PaymentTypeEnum).optional(),
     orderNumber: z.number({ required_error: 'Order number is required' }),

--- a/src/util/zod/zodError-hanlder.ts
+++ b/src/util/zod/zodError-hanlder.ts
@@ -1,0 +1,10 @@
+import { ZodError } from 'zod';
+
+export const zodErrorHandler = (error: ZodError) => {
+  const problem = error.flatten();
+  const fieldErrors = problem.fieldErrors;
+  const fieldErrorsString = Object.entries(fieldErrors)
+    .map(([key, value]) => `${key}: ${value?.join(', ')}`)
+    .join('\n');
+  return fieldErrorsString;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,6 +327,11 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
+"@socket.io/component-emitter@~3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz#821f8442f4175d8f0467b9daf26e3a18e2d02af2"
+  integrity sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
@@ -371,6 +376,18 @@
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz#8c9d23e0b415b24b91626d07017303755d542dc8"
   integrity sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/cors@^2.8.12":
+  version "2.8.17"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.17.tgz#5d718a5e494a8166f569d986794e49c48b216b2b"
+  integrity sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==
   dependencies:
     "@types/node" "*"
 
@@ -434,6 +451,13 @@
   version "20.12.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.7.tgz#04080362fa3dd6c5822061aa3124f5c152cff384"
   integrity sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@>=10.0.0":
+  version "20.14.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.2.tgz#a5f4d2bcb4b6a87bffcaa717718c5a0f208f4a18"
+  integrity sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==
   dependencies:
     undici-types "~5.26.4"
 
@@ -676,7 +700,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-accepts@~1.3.8:
+accepts@~1.3.4, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
@@ -832,6 +856,11 @@ base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+base64id@2.0.0, base64id@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
+  integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
 
 base64url@3.x.x:
   version "3.0.1"
@@ -1201,10 +1230,23 @@ cookie@0.6.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
   integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
+cookie@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cors@~2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig-typescript-loader@^5.0.0:
   version "5.0.0"
@@ -1272,6 +1314,13 @@ debug@4.3.4, debug@4.x, debug@^4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@~4.3.1, debug@~4.3.2, debug@~4.3.4:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
+  integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
   dependencies:
     ms "2.1.2"
 
@@ -1404,6 +1453,27 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
+
+engine.io-parser@~5.2.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.2.2.tgz#37b48e2d23116919a3453738c5720455e64e1c49"
+  integrity sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==
+
+engine.io@~6.5.2:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.5.4.tgz#6822debf324e781add2254e912f8568508850cdc"
+  integrity sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==
+  dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/cors" "^2.8.12"
+    "@types/node" ">=10.0.0"
+    accepts "~1.3.4"
+    base64id "2.0.0"
+    cookie "~0.4.1"
+    cors "~2.8.5"
+    debug "~4.3.1"
+    engine.io-parser "~5.2.1"
+    ws "~8.11.0"
 
 env-paths@^2.2.1:
   version "2.2.1"
@@ -2738,7 +2808,7 @@ oauth@0.10.x:
   resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.10.0.tgz#3551c4c9b95c53ea437e1e21e46b649482339c58"
   integrity sha512-1orQ9MT1vHFGQxhuy7E/0gECD3fd2fCC+PIX+/jgmU/gI3EpRocXtmtvxCO5x3WZ443FLTLFWNDjl5MPJf9u+Q==
 
-object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -3316,6 +3386,35 @@ slice-ansi@^7.0.0:
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^5.0.0"
 
+socket.io-adapter@~2.5.2:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz#4fdb1358667f6d68f25343353bd99bd11ee41006"
+  integrity sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==
+  dependencies:
+    debug "~4.3.4"
+    ws "~8.11.0"
+
+socket.io-parser@~4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.4.tgz#c806966cf7270601e47469ddeec30fbdfda44c83"
+  integrity sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+
+socket.io@^4.7.5:
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.7.5.tgz#56eb2d976aef9d1445f373a62d781a41c7add8f8"
+  integrity sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==
+  dependencies:
+    accepts "~1.3.4"
+    base64id "~2.0.0"
+    cors "~2.8.5"
+    debug "~4.3.2"
+    engine.io "~6.5.2"
+    socket.io-adapter "~2.5.2"
+    socket.io-parser "~4.2.4"
+
 sparse-bitfield@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
@@ -3643,7 +3742,7 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -3722,6 +3821,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@~8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
+  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
1. get `messageListId` from `/api/auth/messageListId`，來取得聊天室的歷史訊息，及傳送訊息
 - 如果本來就已創立，回傳原本id
 - 新訊息，資料庫創立新id
2. socketio url `{{HOST}}?messageListId=`
 - event type `chat message`: 傳送訊息
 - event type `history`: 取得聊天室中的歷史紀錄
 - event type `error` : 取得傳送訊息的錯誤資料，不用throw Error避免連線中斷