### PR TITLE
feat: 🎸 get list and read messages

### DIFF
--- a/postman-collection.json
+++ b/postman-collection.json
@@ -1,9 +1,9 @@
 {
   "info": {
-    "_postman_id": "51722f4b-fbf9-4062-952b-576766be5315",
+    "_postman_id": "a1cdc277-4363-48ec-961e-250c6fac341c",
     "name": "chillka-backend",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "20616853"
+    "_exporter_id": "30654257"
   },
   "item": [
     {
@@ -340,6 +340,25 @@
           "raw": "{{HOST}}/api/activities/comments",
           "host": ["{{HOST}}"],
           "path": ["api", "activities", "comments"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "get message list",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "",
+            "value": "",
+            "disabled": true
+          }
+        ],
+        "url": {
+          "raw": "{{HOST}}/api/auth/messages",
+          "host": ["{{HOST}}"],
+          "path": ["api", "auth", "messages"]
         }
       },
       "response": []

--- a/src/model/message-list.model.ts
+++ b/src/model/message-list.model.ts
@@ -19,6 +19,10 @@ const Message = new Schema<MessageSchemaModel, Message>(
       type: Schema.Types.String,
       required: true,
     },
+    receiverIsRead: {
+      type: Schema.Types.Boolean,
+      default: false,
+    },
   },
   {
     collection: 'messages',

--- a/src/route/message-list.route.ts
+++ b/src/route/message-list.route.ts
@@ -32,6 +32,40 @@ const messageRouter = () => {
     }
   );
 
+  router.get(
+    '/messages',
+    authorizeMiddleware,
+    async (req: Request, res: Response) => {
+      /* #swagger.tags = ['MessageList'] 
+          #swagger.parameters['page'] = {
+            in: 'query',
+            required: false,
+            type: 'number',
+          }
+          #swagger.parameters['limit'] = {
+            in: 'query',
+            required: false,
+            type: 'number',
+          }
+      */
+
+      const userId = req.user?._id;
+      const page = Number(req.query.page);
+      const limit = Number(req.query.limit);
+
+      try {
+        const data = await MessageListService.getMessageList({
+          userId,
+          page,
+          limit,
+        });
+        res.status(200).send(data);
+      } catch (error) {
+        throwAPIError({ res, error, statusCode: 400 });
+      }
+    }
+  );
+
   return router;
 };
 const messageRoute = messageRouter();

--- a/src/route/socket.route.ts
+++ b/src/route/socket.route.ts
@@ -2,25 +2,50 @@ import mongoose from 'mongoose';
 import { Server } from 'socket.io';
 import { ZodError } from 'zod';
 import MessageList from '../model/message-list.model';
-import { SocketQueryParams } from '../type/message-list.type';
+import { MessageUserType, SocketQueryParams } from '../type/message-list.type';
 import { messageSchema } from '../util/zod/message-list.schema';
 import { zodErrorHandler } from '../util/zod/zodError-hanlder';
 
 const socketRoute = (io: Server) => {
   io.on('connection', async (socket) => {
-    const messageListId = (socket.handshake.query as SocketQueryParams)
-      .messageListId;
+    const socketQueryParams = socket.handshake.query as SocketQueryParams;
+    const messageListId = socketQueryParams.messageListId;
+    const userId = socketQueryParams.userId;
 
-    if (!messageListId) {
+    if (!messageListId || !userId) {
       socket.disconnect(true);
       return;
     }
-
     const messageList = await MessageList.findById(
       new mongoose.Types.ObjectId(messageListId)
     );
+    const userObjectId = new mongoose.Types.ObjectId(userId);
+    const userRole = (() => {
+      if (messageList?.hostUserId.equals(userObjectId)) {
+        return 'host';
+      } else if (messageList?.participantUserId.equals(userObjectId)) {
+        return 'participant';
+      }
+    })();
+
+    // update previous history messages to read
+    await MessageList.updateMany(
+      {
+        _id: messageListId,
+        'messages.userType':
+          userRole === 'host'
+            ? MessageUserType.PARTICIPANT
+            : MessageUserType.HOST,
+      },
+      {
+        $set: {
+          'messages.$.receiverIsRead': true,
+        },
+      }
+    );
 
     socket.emit('history', messageList);
+
     socket.on('chat message', async (msg) => {
       try {
         const validatedMsg = messageSchema.parse(msg);

--- a/src/swagger/build/_schema.ts
+++ b/src/swagger/build/_schema.ts
@@ -2733,6 +2733,9 @@ export const _schema = {
         },
         "content": {
           "type": "string"
+        },
+        "receiverIsRead": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -2766,6 +2769,9 @@ export const _schema = {
               },
               "content": {
                 "type": "string"
+              },
+              "receiverIsRead": {
+                "type": "boolean"
               }
             },
             "required": [
@@ -2782,7 +2788,7 @@ export const _schema = {
         "participantUserId"
       ]
     },
-    "GetMessageListParams": {
+    "GetMessageListIdParams": {
       "type": "object",
       "properties": {
         "orderId": {
@@ -2799,6 +2805,23 @@ export const _schema = {
         "hostUserId",
         "orderId",
         "participantUserId"
+      ]
+    },
+    "GetMessageListParams": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "page": {
+          "type": "number"
+        },
+        "limit": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "userId"
       ]
     },
     "LiveMessageParams": {
@@ -2827,6 +2850,9 @@ export const _schema = {
               },
               "content": {
                 "type": "string"
+              },
+              "receiverIsRead": {
+                "type": "boolean"
               }
             },
             "required": [
@@ -2846,12 +2872,16 @@ export const _schema = {
     "SocketQueryParams": {
       "type": "object",
       "properties": {
+        "userId": {
+          "type": "string"
+        },
         "messageListId": {
           "type": "string"
         }
       },
       "required": [
-        "messageListId"
+        "messageListId",
+        "userId"
       ]
     },
     "PaymentStatusEnum": {

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -27,6 +27,23 @@
         }
       }
     },
+    "/api/mock-activity": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/register": {
       "post": {
         "tags": ["Auth"],
@@ -114,7 +131,41 @@
         }
       }
     },
+    "/api/activities/recommend": {
+      "get": {
+        "tags": ["Activity"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/activities/popular-keywords": {
+      "get": {
+        "tags": ["Activity"],
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/activities/comments": {
       "get": {
         "tags": ["Activity"],
         "description": "",
@@ -645,7 +696,7 @@
       }
     },
     "/api/auth/payment": {
-      "get": {
+      "post": {
         "tags": ["Payment"],
         "description": "",
         "parameters": [
@@ -680,6 +731,36 @@
             "schema": {
               "$ref": "#/schemas/GetMessageListParams"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/api/auth/messages": {
+      "get": {
+        "tags": ["MessageList"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "type": "number"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "number"
           }
         ],
         "responses": {
@@ -758,6 +839,12 @@
             "$ref": "#/definitions/Types.ObjectId"
           }
         },
+        "favoriteCategories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "displayName": {
           "type": "string"
         },
@@ -768,7 +855,7 @@
           "type": "string"
         }
       },
-      "required": ["displayName", "email", "password"]
+      "required": ["displayName", "email", "favoriteCategories", "password"]
     },
     "UserRegisterCredentials": {
       "allOf": [
@@ -873,9 +960,15 @@
           "items": {
             "$ref": "#/definitions/Types.ObjectId"
           }
+        },
+        "favoriteCategories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
-      "required": ["displayName", "email"]
+      "required": ["displayName", "email", "favoriteCategories"]
     },
     "SendEmailCredentials": {
       "type": "object",
@@ -1080,6 +1173,9 @@
         "participantCapacity": {
           "type": "number"
         },
+        "soldNumber": {
+          "type": "number"
+        },
         "unlimitedQuantity": {
           "type": "boolean"
         },
@@ -1108,6 +1204,7 @@
         "price",
         "purchaseDuplicate",
         "purchaseLimit",
+        "soldNumber",
         "startDateTime",
         "ticketStatus",
         "unlimitedQuantity"
@@ -1142,6 +1239,9 @@
         "participantCapacity": {
           "type": "number"
         },
+        "soldNumber": {
+          "type": "number"
+        },
         "unlimitedQuantity": {
           "type": "boolean"
         },
@@ -1166,6 +1266,7 @@
         "price",
         "purchaseDuplicate",
         "purchaseLimit",
+        "soldNumber",
         "startDateTime",
         "ticketStatus",
         "unlimitedQuantity"
@@ -1359,6 +1460,9 @@
         "displayRemainingTickets": {
           "type": "boolean"
         },
+        "remainingTickets": {
+          "type": "number"
+        },
         "isRecurring": {
           "type": "boolean"
         },
@@ -1434,6 +1538,9 @@
               "participantCapacity": {
                 "type": "number"
               },
+              "soldNumber": {
+                "type": "number"
+              },
               "unlimitedQuantity": {
                 "type": "boolean"
               },
@@ -1462,6 +1569,7 @@
               "price",
               "purchaseDuplicate",
               "purchaseLimit",
+              "soldNumber",
               "startDateTime",
               "ticketStatus",
               "unlimitedQuantity"
@@ -1475,10 +1583,22 @@
           }
         },
         "lat": {
-          "type": "string"
+          "type": "number"
         },
         "lng": {
-          "type": "string"
+          "type": "number"
+        },
+        "saved": {
+          "type": "boolean"
+        },
+        "participated": {
+          "type": "boolean"
+        },
+        "participantCapacity": {
+          "type": "number"
+        },
+        "unlimitedQuantity": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -1488,7 +1608,6 @@
         "creatorId",
         "details",
         "displayRemainingTickets",
-        "endDateTime",
         "fromToday",
         "isPrivate",
         "isRecurring",
@@ -1499,14 +1618,18 @@
         "name",
         "noEndDate",
         "organizer",
+        "participantCapacity",
+        "participated",
         "questions",
         "recurring",
-        "startDateTime",
+        "remainingTickets",
+        "saved",
         "status",
         "summary",
         "thumbnail",
         "tickets",
-        "type"
+        "type",
+        "unlimitedQuantity"
       ]
     },
     "ActivityCreateParams": {
@@ -1614,6 +1737,9 @@
         "displayRemainingTickets": {
           "type": "boolean"
         },
+        "remainingTickets": {
+          "type": "number"
+        },
         "isRecurring": {
           "type": "boolean"
         },
@@ -1689,6 +1815,9 @@
               "participantCapacity": {
                 "type": "number"
               },
+              "soldNumber": {
+                "type": "number"
+              },
               "unlimitedQuantity": {
                 "type": "boolean"
               },
@@ -1717,6 +1846,7 @@
               "price",
               "purchaseDuplicate",
               "purchaseLimit",
+              "soldNumber",
               "startDateTime",
               "ticketStatus",
               "unlimitedQuantity"
@@ -1730,10 +1860,22 @@
           }
         },
         "lat": {
-          "type": "string"
+          "type": "number"
         },
         "lng": {
-          "type": "string"
+          "type": "number"
+        },
+        "saved": {
+          "type": "boolean"
+        },
+        "participated": {
+          "type": "boolean"
+        },
+        "participantCapacity": {
+          "type": "number"
+        },
+        "unlimitedQuantity": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -1743,7 +1885,6 @@
         "creatorId",
         "details",
         "displayRemainingTickets",
-        "endDateTime",
         "fromToday",
         "isPrivate",
         "isRecurring",
@@ -1754,14 +1895,18 @@
         "name",
         "noEndDate",
         "organizer",
+        "participantCapacity",
+        "participated",
         "questions",
         "recurring",
-        "startDateTime",
+        "remainingTickets",
+        "saved",
         "status",
         "summary",
         "thumbnail",
         "tickets",
-        "type"
+        "type",
+        "unlimitedQuantity"
       ]
     },
     "ActivityCreateCredentials": {
@@ -1807,6 +1952,12 @@
         "noEndDate": {
           "type": "boolean"
         },
+        "participantCapacity": {
+          "type": "number"
+        },
+        "unlimitedQuantity": {
+          "type": "boolean"
+        },
         "organizer": {
           "type": "object",
           "properties": {
@@ -1869,6 +2020,9 @@
         },
         "displayRemainingTickets": {
           "type": "boolean"
+        },
+        "remainingTickets": {
+          "type": "number"
         },
         "isRecurring": {
           "type": "boolean"
@@ -1941,6 +2095,9 @@
               "participantCapacity": {
                 "type": "number"
               },
+              "soldNumber": {
+                "type": "number"
+              },
               "unlimitedQuantity": {
                 "type": "boolean"
               },
@@ -1969,6 +2126,7 @@
               "price",
               "purchaseDuplicate",
               "purchaseLimit",
+              "soldNumber",
               "startDateTime",
               "ticketStatus",
               "unlimitedQuantity"
@@ -1982,10 +2140,16 @@
           }
         },
         "lat": {
-          "type": "string"
+          "type": "number"
         },
         "lng": {
-          "type": "string"
+          "type": "number"
+        },
+        "saved": {
+          "type": "boolean"
+        },
+        "participated": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -1994,7 +2158,6 @@
         "cover",
         "details",
         "displayRemainingTickets",
-        "endDateTime",
         "fromToday",
         "isPrivate",
         "isRecurring",
@@ -2005,14 +2168,18 @@
         "name",
         "noEndDate",
         "organizer",
+        "participantCapacity",
+        "participated",
         "questions",
         "recurring",
-        "startDateTime",
+        "remainingTickets",
+        "saved",
         "status",
         "summary",
         "thumbnail",
         "tickets",
-        "type"
+        "type",
+        "unlimitedQuantity"
       ]
     },
     "EditableActivity": {
@@ -2058,6 +2225,12 @@
         "noEndDate": {
           "type": "boolean"
         },
+        "participantCapacity": {
+          "type": "number"
+        },
+        "unlimitedQuantity": {
+          "type": "boolean"
+        },
         "organizer": {
           "type": "object",
           "properties": {
@@ -2120,6 +2293,9 @@
         },
         "displayRemainingTickets": {
           "type": "boolean"
+        },
+        "remainingTickets": {
+          "type": "number"
         },
         "isRecurring": {
           "type": "boolean"
@@ -2192,6 +2368,9 @@
               "participantCapacity": {
                 "type": "number"
               },
+              "soldNumber": {
+                "type": "number"
+              },
               "unlimitedQuantity": {
                 "type": "boolean"
               },
@@ -2220,6 +2399,7 @@
               "price",
               "purchaseDuplicate",
               "purchaseLimit",
+              "soldNumber",
               "startDateTime",
               "ticketStatus",
               "unlimitedQuantity"
@@ -2227,10 +2407,16 @@
           }
         },
         "lat": {
-          "type": "string"
+          "type": "number"
         },
         "lng": {
-          "type": "string"
+          "type": "number"
+        },
+        "saved": {
+          "type": "boolean"
+        },
+        "participated": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -2239,7 +2425,6 @@
         "cover",
         "details",
         "displayRemainingTickets",
-        "endDateTime",
         "fromToday",
         "isPrivate",
         "isRecurring",
@@ -2250,13 +2435,17 @@
         "name",
         "noEndDate",
         "organizer",
+        "participantCapacity",
+        "participated",
         "recurring",
-        "startDateTime",
+        "remainingTickets",
+        "saved",
         "status",
         "summary",
         "thumbnail",
         "tickets",
-        "type"
+        "type",
+        "unlimitedQuantity"
       ]
     },
     "ActivityEditParams": {
@@ -2302,6 +2491,12 @@
               "format": "date-time"
             },
             "noEndDate": {
+              "type": "boolean"
+            },
+            "participantCapacity": {
+              "type": "number"
+            },
+            "unlimitedQuantity": {
               "type": "boolean"
             },
             "organizer": {
@@ -2366,6 +2561,9 @@
             },
             "displayRemainingTickets": {
               "type": "boolean"
+            },
+            "remainingTickets": {
+              "type": "number"
             },
             "isRecurring": {
               "type": "boolean"
@@ -2438,6 +2636,9 @@
                   "participantCapacity": {
                     "type": "number"
                   },
+                  "soldNumber": {
+                    "type": "number"
+                  },
                   "unlimitedQuantity": {
                     "type": "boolean"
                   },
@@ -2466,6 +2667,7 @@
                   "price",
                   "purchaseDuplicate",
                   "purchaseLimit",
+                  "soldNumber",
                   "startDateTime",
                   "ticketStatus",
                   "unlimitedQuantity"
@@ -2473,10 +2675,16 @@
               }
             },
             "lat": {
-              "type": "string"
+              "type": "number"
             },
             "lng": {
-              "type": "string"
+              "type": "number"
+            },
+            "saved": {
+              "type": "boolean"
+            },
+            "participated": {
+              "type": "boolean"
             }
           },
           "required": [
@@ -2485,7 +2693,6 @@
             "cover",
             "details",
             "displayRemainingTickets",
-            "endDateTime",
             "fromToday",
             "isPrivate",
             "isRecurring",
@@ -2496,13 +2703,17 @@
             "name",
             "noEndDate",
             "organizer",
+            "participantCapacity",
+            "participated",
             "recurring",
-            "startDateTime",
+            "remainingTickets",
+            "saved",
             "status",
             "summary",
             "thumbnail",
             "tickets",
-            "type"
+            "type",
+            "unlimitedQuantity"
           ]
         },
         {
@@ -2560,6 +2771,12 @@
           "format": "date-time"
         },
         "noEndDate": {
+          "type": "boolean"
+        },
+        "participantCapacity": {
+          "type": "number"
+        },
+        "unlimitedQuantity": {
           "type": "boolean"
         },
         "organizer": {
@@ -2624,6 +2841,9 @@
         },
         "displayRemainingTickets": {
           "type": "boolean"
+        },
+        "remainingTickets": {
+          "type": "number"
         },
         "isRecurring": {
           "type": "boolean"
@@ -2696,6 +2916,9 @@
               "participantCapacity": {
                 "type": "number"
               },
+              "soldNumber": {
+                "type": "number"
+              },
               "unlimitedQuantity": {
                 "type": "boolean"
               },
@@ -2724,6 +2947,7 @@
               "price",
               "purchaseDuplicate",
               "purchaseLimit",
+              "soldNumber",
               "startDateTime",
               "ticketStatus",
               "unlimitedQuantity"
@@ -2731,10 +2955,16 @@
           }
         },
         "lat": {
-          "type": "string"
+          "type": "number"
         },
         "lng": {
-          "type": "string"
+          "type": "number"
+        },
+        "saved": {
+          "type": "boolean"
+        },
+        "participated": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -2743,7 +2973,6 @@
         "cover",
         "details",
         "displayRemainingTickets",
-        "endDateTime",
         "fromToday",
         "isPrivate",
         "isRecurring",
@@ -2754,13 +2983,17 @@
         "name",
         "noEndDate",
         "organizer",
+        "participantCapacity",
+        "participated",
         "recurring",
-        "startDateTime",
+        "remainingTickets",
+        "saved",
         "status",
         "summary",
         "thumbnail",
         "tickets",
-        "type"
+        "type",
+        "unlimitedQuantity"
       ]
     },
     "GetActivitiesParams": {
@@ -2939,6 +3172,46 @@
         "size"
       ]
     },
+    "GetRecommendActivitiesCredential": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "number"
+        }
+      },
+      "required": ["limit"]
+    },
+    "CommentSchemaModel": {
+      "type": "object",
+      "properties": {
+        "profilePicture": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "content": {
+          "type": "string"
+        },
+        "activityName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "activityName",
+        "content",
+        "date",
+        "profilePicture",
+        "userName"
+      ]
+    },
     "KeywordSchemaModel": {
       "type": "object",
       "properties": {
@@ -2964,6 +3237,9 @@
         },
         "content": {
           "type": "string"
+        },
+        "receiverIsRead": {
+          "type": "boolean"
         }
       },
       "required": ["content", "userType"]
@@ -2991,6 +3267,9 @@
               },
               "content": {
                 "type": "string"
+              },
+              "receiverIsRead": {
+                "type": "boolean"
               }
             },
             "required": ["content", "userType"]
@@ -2999,7 +3278,7 @@
       },
       "required": ["hostUserId", "messages", "orderId", "participantUserId"]
     },
-    "GetMessageListParams": {
+    "GetMessageListIdParams": {
       "type": "object",
       "properties": {
         "orderId": {
@@ -3013,6 +3292,21 @@
         }
       },
       "required": ["hostUserId", "orderId", "participantUserId"]
+    },
+    "GetMessageListParams": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "$ref": "#/definitions/Types.ObjectId"
+        },
+        "page": {
+          "type": "number"
+        },
+        "limit": {
+          "type": "number"
+        }
+      },
+      "required": ["userId"]
     },
     "LiveMessageParams": {
       "type": "object",
@@ -3037,6 +3331,9 @@
               },
               "content": {
                 "type": "string"
+              },
+              "receiverIsRead": {
+                "type": "boolean"
               }
             },
             "required": ["content", "userType"]
@@ -3048,11 +3345,14 @@
     "SocketQueryParams": {
       "type": "object",
       "properties": {
+        "userId": {
+          "type": "string"
+        },
         "messageListId": {
           "type": "string"
         }
       },
-      "required": ["messageListId"]
+      "required": ["messageListId", "userId"]
     },
     "PaymentStatusEnum": {
       "type": "string",

--- a/src/type/message-list.type.ts
+++ b/src/type/message-list.type.ts
@@ -8,6 +8,7 @@ export enum MessageUserType {
 export interface MessageSchemaModel {
   userType: MessageUserType;
   content: string;
+  receiverIsRead?: boolean;
 }
 
 export interface MessageListSchemaModel {
@@ -17,14 +18,21 @@ export interface MessageListSchemaModel {
   messages: MessageSchemaModel[];
 }
 
-export type GetMessageListParams = {
+export type GetMessageListIdParams = {
   orderId: string;
   hostUserId: string;
   participantUserId: string;
 };
 
+export type GetMessageListParams = {
+  userId: mongoose.Types.ObjectId | undefined;
+  page?: number;
+  limit?: number;
+};
+
 export type LiveMessageParams = MessageListSchemaModel;
 
 export type SocketQueryParams = {
+  userId: string;
   messageListId: string;
 };


### PR DESCRIPTION
新增：
1. websocket url 需回傳userId, 來做已讀訊息的判斷。
2. message model 加上`receiverIsRead` boolean field, 後端判斷user 是host / participant, 如果是host, 跟新之前歷史紀錄中userType === 參與者的訊息為true; 反之亦然
```
// eg: update receiverIsRead to true
{
  "userType": "參與者",
  "content": "send test message",
  "receiverIsRead": true,
}
```

